### PR TITLE
地理院標高タイル改を敷く

### DIFF
--- a/example-gsibv.html
+++ b/example-gsibv.html
@@ -81,7 +81,7 @@
       };
       
       style.fog = {
-        range: [2, 12],
+        range: [-1, 10],
         color: [
           "rgb",
           255,

--- a/example-gsibv.html
+++ b/example-gsibv.html
@@ -81,7 +81,7 @@
       };
       
       style.fog = {
-        range: [-5, 1],
+        range: [-5, 5],
         color: [
           "rgb",
           255,

--- a/example-gsibv.html
+++ b/example-gsibv.html
@@ -66,6 +66,7 @@
         source: "h"
       };
 
+      mapboxgl.accessToken = 'pk.eyJ1IjoiaGZ1IiwiYSI6ImlRSGJVUTAifQ.rTx380smyvPc1gUfZv1cmw';
       new mapboxgl.Map({
         "container": "map",
         "center": [139.68786, 35.68355],

--- a/example-gsibv.html
+++ b/example-gsibv.html
@@ -59,9 +59,9 @@
         "paint": {
           "background-color": [
             "rgb",
-            194,
-            209,
-            251
+            255,
+            255,
+            255
           ]
         },
         "type": "background"
@@ -76,7 +76,8 @@
       });
       
       style.terrain = {
-        source: "h"
+        source: "h",
+        "exaggeration": 3
       };
 
       mapboxgl.accessToken = 'pk.eyJ1IjoiaGZ1IiwiYSI6ImlRSGJVUTAifQ.rTx380smyvPc1gUfZv1cmw';

--- a/example-gsibv.html
+++ b/example-gsibv.html
@@ -81,7 +81,7 @@
       };
 
       mapboxgl.accessToken = 'pk.eyJ1IjoiaGZ1IiwiYSI6ImlRSGJVUTAifQ.rTx380smyvPc1gUfZv1cmw';
-      new mapboxgl.Map({
+      map = new mapboxgl.Map({
         "container": "map",
         "center": [139.68786, 35.68355],
         "zoom": 14.65,
@@ -89,6 +89,11 @@
         "bearing": 22,
         "hash": true,
         "style": style
+      });
+      map.setFog({
+        range: [2, 12],
+        color: 'white',
+        "horizon-blend": 0.1
       });
     });
   </script>

--- a/example-gsibv.html
+++ b/example-gsibv.html
@@ -81,7 +81,7 @@
       };
       
       style.fog = {
-        range: [-5, 5],
+        range: [-2, 10],
         color: [
           "rgb",
           255,

--- a/example-gsibv.html
+++ b/example-gsibv.html
@@ -79,6 +79,17 @@
         source: "h",
         "exaggeration": 3
       };
+      
+      style.fog = {
+        range: [2, 12],
+        color: [
+          "rgb",
+          255,
+          255,
+          255
+        ],
+        "horizon-blend": 0.1
+      };
 
       mapboxgl.accessToken = 'pk.eyJ1IjoiaGZ1IiwiYSI6ImlRSGJVUTAifQ.rTx380smyvPc1gUfZv1cmw';
       map = new mapboxgl.Map({
@@ -89,11 +100,6 @@
         "bearing": 22,
         "hash": true,
         "style": style
-      });
-      map.setFog({
-        range: [2, 12],
-        color: 'white',
-        "horizon-blend": 0.1
       });
     });
   </script>

--- a/example-gsibv.html
+++ b/example-gsibv.html
@@ -55,6 +55,19 @@
       );
       
       style.layers.unshift({
+        "id": "background",
+        "paint": {
+          "background-color": [
+            "rgb",
+            194,
+            209,
+            251
+          ]
+        },
+        "type": "background"
+      });
+      
+      style.layers.unshift({
         "id": "sky",
         "paint": {
           "sky-type": "atmosphere"

--- a/example-gsibv.html
+++ b/example-gsibv.html
@@ -5,15 +5,19 @@
   <meta charset="UTF-8">
   <title>example-gsibv</title>
   <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0" />
-  <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@1.14.0/dist/maplibre-gl.css" />
-  <script src="https://unpkg.com/maplibre-gl@1.14.0/dist/maplibre-gl.js"></script>
+  <link rel="stylesheet" href="https://api.mapbox.com/mapbox-gl-js/v2.3.0/mapbox-gl.css" />
+  <script src="https://api.mapbox.com/mapbox-gl-js/v2.3.0/mapbox-gl.js"></script>
 </head>
 
 <body>
   <div id="map" style="position:absolute;top:0;left:0;bottom:0;right:0;"></div>
   <script>
     fetch("https://gsi-cyberjapan.github.io/gsivectortile-mapbox-gl-js/std.json").then(res => res.json()).then(style => {
-
+      
+      for(layer in style.layers) {
+        if (layer.maxzoom == 18) layer.maxzoom = 24
+      }
+      
       style.sources.plateau = {
         "type": "vector",
         "tiles": [
@@ -22,6 +26,16 @@
         "minzoom": 10,
         "maxzoom": 16,
         "attribution": "<a href='https://github.com/indigo-lab/plateau-tokyo23ku-building-mvt-2020'>plateau-tokyo23ku-building-mvt-2020 by indigo-lab</a> (<a href='https://www.mlit.go.jp/plateau/'>国土交通省 Project PLATEAU</a> のデータを加工して作成)"
+      };
+      
+      style.sources.h = {
+        "maxzoom": 13,
+        "minzoom": 3,
+        "tileSize": 512,
+        "tiles": [
+          "https://optgeo.github.io/10b512-7-113-50/zxy/{z}/{x}/{y}.webp"
+        ],
+        "type": "raster-dem"
       };
 
       style.layers = [].concat(
@@ -39,8 +53,20 @@
         },
         style.layers.filter(a => a.type === "symbol")
       );
+      
+      style.layers.unshift({
+        "id": "sky",
+        "paint": {
+          "sky-type": "atmosphere"
+        },
+        "type": "sky"
+      });
+      
+      style.terrain = {
+        source: "h"
+      };
 
-      new maplibregl.Map({
+      new mapboxgl.Map({
         "container": "map",
         "center": [139.68786, 35.68355],
         "zoom": 14.65,

--- a/example-gsibv.html
+++ b/example-gsibv.html
@@ -81,7 +81,7 @@
       };
       
       style.fog = {
-        range: [-1, 10],
+        range: [-5, 1],
         color: [
           "rgb",
           255,


### PR DESCRIPTION
地理院標高タイル改を敷く、`example-gsibv.html` のバリエーションを作ってみました。

Mapbox GL JS v2 を使うものなので、方針に合わなければこの PR は無視・削除してください。サンプルサイトは

https://optgeo.github.io/plateau-tokyo23ku-building-mvt-2020/example-gsibv.html#17.88/35.735353/139.764034/-51.8/73

です。

仮にマージしてくださる場合は、マージ後 `mapboxgl.accessToken` の値を書き換えていただけると助かります。